### PR TITLE
chore: CW-21443 update nodejs

### DIFF
--- a/.github/workflows/apply_terraform.yml
+++ b/.github/workflows/apply_terraform.yml
@@ -71,13 +71,13 @@ jobs:
 
       - name: Authenticate gcloud
         if: ${{ env.GCP_ENV == 'production' }}
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.PROD_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
 
       - name: Authenticate gcloud
         if: ${{ env.GCP_ENV == 'develop' }}
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
 

--- a/.github/workflows/apply_terraform.yml
+++ b/.github/workflows/apply_terraform.yml
@@ -82,9 +82,9 @@ jobs:
           credentials_json: ${{ secrets.DEV_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
 
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.5.x
           terraform_wrapper: false

--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign Reviewers to PR
-        uses: kentaro-m/auto-assign-action@v1.2.4
+        uses: kentaro-m/auto-assign-action@v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_and_publish_npm_package.yml
+++ b/.github/workflows/build_and_publish_npm_package.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - run: |
           echo "@coolbitx-technology:registry=https://npm.pkg.github.com/" > .npmrc && \
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.DEVOPS_WRITE_PACKAGE_TOKEN }}" >> .npmrc && \

--- a/.github/workflows/build_and_publish_npm_package.yml
+++ b/.github/workflows/build_and_publish_npm_package.yml
@@ -12,8 +12,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - run: |

--- a/.github/workflows/build_and_publish_npm_package.yml
+++ b/.github/workflows/build_and_publish_npm_package.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 16
       - run: |
           echo "@coolbitx-technology:registry=https://npm.pkg.github.com/" > .npmrc && \
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.DEVOPS_WRITE_PACKAGE_TOKEN }}" >> .npmrc && \

--- a/.github/workflows/build_and_publish_official_public_npm_package.yml
+++ b/.github/workflows/build_and_publish_official_public_npm_package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/build_and_publish_official_public_npm_package.yml
+++ b/.github/workflows/build_and_publish_official_public_npm_package.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 18
           registry-url: https://registry.npmjs.org/
           scope: '@coolbitx'
       - run: npm ci

--- a/.github/workflows/build_and_publish_official_public_npm_package.yml
+++ b/.github/workflows/build_and_publish_official_public_npm_package.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.org/
           scope: '@coolbitx'
       - run: npm ci

--- a/.github/workflows/build_and_test_image.yml
+++ b/.github/workflows/build_and_test_image.yml
@@ -61,7 +61,7 @@ jobs:
         if: contains('refs/heads/dev refs/heads/master', github.ref)
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: image
           path: image.tar

--- a/.github/workflows/build_and_test_image.yml
+++ b/.github/workflows/build_and_test_image.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Save image
         run: |
           docker save -o image.tar ${IMAGE_NAME}:${IMAGE_TAG_SHA}
-        if: contains('refs/heads/Update-Nodejs refs/heads/master', github.ref)
+        if: contains('refs/heads/dev refs/heads/master', github.ref)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -66,4 +66,4 @@ jobs:
           name: image
           path: image.tar
           retention-days: 5
-        if: contains('refs/heads/Update-Nodejs refs/heads/master', github.ref)
+        if: contains('refs/heads/dev refs/heads/master', github.ref)

--- a/.github/workflows/build_and_test_image.yml
+++ b/.github/workflows/build_and_test_image.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Save image
         run: |
           docker save -o image.tar ${IMAGE_NAME}:${IMAGE_TAG_SHA}
-        if: contains('refs/heads/dev refs/heads/master', github.ref)
+        if: contains('refs/heads/Update-Nodejs refs/heads/master', github.ref)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -66,4 +66,4 @@ jobs:
           name: image
           path: image.tar
           retention-days: 5
-        if: contains('refs/heads/dev refs/heads/master', github.ref)
+        if: contains('refs/heads/Update-Nodejs refs/heads/master', github.ref)

--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: technote-space/workflow-conclusion-action@v3
+      - uses: technote-space/workflow-conclusion-action@v4
         if: ${{ ! env.ACT }}
 
       - name: vars

--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: technote-space/workflow-conclusion-action@v3
+      - uses: technote-space/workflow-conclusion-action@v3.0.3
         if: ${{ ! env.ACT }}
 
       - name: vars

--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -46,7 +46,7 @@ jobs:
           echo "status=${STATUS}" >> $GITHUB_OUTPUT
 
       - name: slack_notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@v2.3.0
         env:
           SLACK_WEBHOOK: ${{ secrets.CP_SLACK_CHANNEL_RG_CRYPTO }}
           SLACK_USERNAME: Github Action

--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: technote-space/workflow-conclusion-action@v4
+      - uses: technote-space/workflow-conclusion-action@v3
         if: ${{ ! env.ACT }}
 
       - name: vars

--- a/.github/workflows/plan_terraform.yml
+++ b/.github/workflows/plan_terraform.yml
@@ -55,20 +55,20 @@ jobs:
 
       - name: Authenticate gcloud
         if: ${{ env.GCP_ENV == 'production' }}
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.PROD_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
 
       - name: Authenticate gcloud
         if: ${{ env.GCP_ENV == 'develop' }}
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
 
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.5.x
 

--- a/.github/workflows/pr-action.yml
+++ b/.github/workflows/pr-action.yml
@@ -51,7 +51,7 @@ jobs:
     needs:
       - unit_test
     steps:
-      - uses: technote-space/workflow-conclusion-action@v3
+      - uses: technote-space/workflow-conclusion-action@v4
         if: ${{ ! env.ACT }}
 
       - name: vars

--- a/.github/workflows/pr-action.yml
+++ b/.github/workflows/pr-action.yml
@@ -51,7 +51,7 @@ jobs:
     needs:
       - unit_test
     steps:
-      - uses: technote-space/workflow-conclusion-action@v4
+      - uses: technote-space/workflow-conclusion-action@v3.0.3
         if: ${{ ! env.ACT }}
 
       - name: vars

--- a/.github/workflows/pr-action.yml
+++ b/.github/workflows/pr-action.yml
@@ -86,7 +86,7 @@ jobs:
           echo "status=${STATUS}" >> $GITHUB_OUTPUT
 
       - name: slack_notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@v2.3.0
         env:
           SLACK_WEBHOOK: ${{ secrets.CP_SLACK_CHANNEL_RG_CRYPTO }}
           SLACK_USERNAME: Github Action

--- a/.github/workflows/push_and_rotate_image.yml
+++ b/.github/workflows/push_and_rotate_image.yml
@@ -53,21 +53,21 @@ jobs:
 
       - name: Authenticate gcloud
         if: ${{ env.GCP_ENV == 'production' }}
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.PROD_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
 
       - name: Authenticate gcloud
         if: ${{ env.GCP_ENV == 'develop' }}
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: image
           path: .

--- a/.github/workflows/run_integration_test.yml
+++ b/.github/workflows/run_integration_test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Workflow dispatch
-        uses: benc-uk/workflow-dispatch@v1.1
+        uses: benc-uk/workflow-dispatch@v1.2.4
         with:
           repo: CoolBitX-Technology/api-automation 
           ref: master


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary:**
Upgraded Google Cloud authentication and setup-terraform actions, as well as some GitHub Actions workflows to their latest versions. Introduced new versions of `actions/upload-artifact`, `google-github-actions/auth`, and `technote-space/workflow-conclusion-action`.

**Summary:**
- Upgraded `google-github-actions/setup-gcloud` to version 2 and updated `actions/download-artifact` to version 4.
- Updated `benc-uk/workflow-dispatch` to version 1.2.4.

**Key Points:**
- Dependency Upgrade: `google-github-actions/setup-gcloud` from v1 to v2.
- Dependency Update: `actions/download-artifact` from v3 to v4.
- Dependency Update: `google-github-actions/auth` from v1 to v2.
- Dependency Update: `technote-space/workflow-conclusion-action` from v3 to v3.0.3.
- Workflow Update: `benc-uk/workflow-dispatch` from v1.1 to v1.2.4.

**Changes:**

**Actions:**
- `google-github-actions/setup-gcloud@v1` has been replaced with `google-github-actions/setup-gcloud@v2` in `.github/workflows/plan_terraform.yml` and `.github/workflows/pr-action.yml`.
- `actions/download-artifact@v3` has been replaced with `actions/download-artifact@v4` in `.github/workflows/build.yml`, `.github/workflows/plan_terraform.yml`, `.github/workflows/pr-action.yml`, and `.github/workflows/notify_slack.yml`.
- `google-github-actions/auth@v1` has been replaced with `google-github-actions/auth@v2` in `.github/workflows/apply_terraform.yml`, `.github/workflows/assign_reviewers.yml`, `.github/workflows/build_and_publish_npm_package.yml`, `.github/workflows/build_and_publish_official_public_npm_package.yml`, `.github/workflows/plan_terraform.yml`, and `.github/workflows/pr-action.yml`.
- `technote-space/workflow-conclusion-action@v3` has been replaced with `technote-space/workflow-conclusion-action@v3.0.3` in `.github/workflows/pr-action.yml` and `.github/workflows/notify_slack.yml`.

**Workflows:**
- `apply_terraform.yml`, `assign_reviewers.yml`, `build_and_publish_npm_package.yml`, and `build_and_publish_official_public_npm_package.yml`: The versions of `google-github-actions/auth` and `hashicorp/setup-terraform` have been updated.
- `notify_slack.yml`: The versions of `technote-space/workflow-conclusion-action` and `google-github-actions/auth` have been updated.
- `plan_terraform.yml` and `pr-action.yml`: The versions of `google-github-actions/auth`, `google-github-actions/setup-gcloud`, and `hashicorp/setup-terraform` have been updated. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>