### PR TITLE
chore: skip terraform workflows for dependabot PRs

### DIFF
--- a/.github/workflows/apply_terraform.yml
+++ b/.github/workflows/apply_terraform.yml
@@ -26,6 +26,7 @@ on:
 
 jobs:
   apply_terraform:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     outputs:
       TEST_ENDPOINT: ${{ steps.terraform_output.outputs.test_endpoint }}

--- a/.github/workflows/plan_terraform.yml
+++ b/.github/workflows/plan_terraform.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   plan_terraform:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main


### PR DESCRIPTION
Dependabot PR 只要跑 build/test 就好，不需要也不該動到 infra，所以plan_terraform.yml和apply_terraform.yml應該要排除dependabot pr
 
 **PR Summary by Typo**
------------

#### Overview
This PR introduces a change to skip Terraform workflows for Dependabot pull requests. This prevents unnecessary workflow runs when Dependabot updates dependencies.

#### Key Changes
- Added a conditional check `if: ${{ github.actor != 'dependabot[bot]' }}` to the `apply_terraform.yml` and `plan_terraform.yml` workflows.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| New Work | 2 (100.0%)    |
| Total Changes | 2         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>