### PR TITLE
[CW-28153] fix: configure npm auth on runner before npm ci

### DIFF
--- a/.github/workflows/unit_test_than_build_image.yml
+++ b/.github/workflows/unit_test_than_build_image.yml
@@ -28,9 +28,12 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Configure npm auth
         env:
           NPM_TOKEN: ${{ secrets.DEVOPS_READ_PACKAGE_TOKEN }}
+        run: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+
+      - name: Install dependencies
         run: npm ci
 
       - name: Unit test


### PR DESCRIPTION
## Summary

- Add a `Configure npm auth` step that writes `//npm.pkg.github.com/:_authToken=${NPM_TOKEN}` to `~/.npmrc` before `npm ci` runs.
- Move the `NPM_TOKEN` env from the `Install dependencies` step to the new auth step (npm itself never read that env var; only the `.npmrc` line uses it).

## Why

Previously the `unit_test` job set `NPM_TOKEN` as an env var on the `npm ci` step, expecting npm to pick it up. **It doesn't** — npm only honours `.npmrc` entries that reference `${NPM_TOKEN}`. The old docker-based workflow worked because each service repo's Dockerfile wrote `.npmrc` at image build time. On the runner there's no such step, so `npm ci` hits **401 Unauthorized** against `npm.pkg.github.com` for private `@CoolBitX-Technology` packages.

Failing run that surfaced this: https://github.com/CoolBitX-Technology/cp-user-registration/actions/runs/25309932225/job/74194197241

```
npm error code E401
npm error 401 Unauthorized - GET https://npm.pkg.github.com/download/@CoolBitX-Technology/eslint-config-cp/...
- authentication token not provided
```

## Test Plan

- [ ] 重跑 `cp-user-registration` 那條 branch 的 CI，確認 `unit_test` job 通過 `npm ci` 並進入 `npm test`
- [ ] 確認 `build_image` job 行為不變（artifact 仍正常上傳）
- [ ] 在另一個 service repo 試跑一次以避免 `cp-user-registration` 特例

## Related

- Task: https://app.clickup.com/t/25577573/CW-28153
- Original feature PR: #39
- Plan: `docs/plans/2026-05-04-unit-test-then-build-workflow.md`
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses an issue in the CI pipeline where npm authentication was not properly configured before dependency installation, causing `npm ci` to fail when accessing private packages.

#### Key Changes
- A new step has been added to the `unit_test_than_build_image.yml` GitHub Actions workflow to configure npm authentication.
- This step writes the `DEVOPS_READ_PACKAGE_TOKEN` to the `.npmrc` file, ensuring authentication is set up before `npm ci` runs.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 3 (75.0%)     |
| Rework      | 1 (25.0%)     |
| Total Changes | 4             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>