### PR TITLE
feat: centralize reviewer assignment and update README

### DIFF
--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -1,14 +1,37 @@
 name: Assign Reviewers
 
-on: 
+on:
+  workflow_call:
   pull_request:
-    types: 
-      [ready_for_review, opened]
+    types: [ready_for_review, opened]
+
 jobs:
-  build:
+  assign:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - name: Assign Reviewers to PR
-        uses: kentaro-m/auto-assign-action@v2.0.0
+      - name: Assign reviewers
+        uses: actions/github-script@v7
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const REVIEWERS = [
+              'and2352000',        // Aaron
+              'Dorac',             // Dora
+              'hankliu418',        // Hank Liu
+              'GinaYYoung',        // Gina
+              'hongyuCoolbitx',    // Hongyu
+              'suntsai-coolbitx',  // Sun
+            ];
+
+            const author = context.payload.pull_request.user.login.toLowerCase();
+            const reviewers = REVIEWERS.filter(r => r.toLowerCase() !== author);
+
+            if (reviewers.length === 0) return;
+
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers,
+            });

--- a/README.md
+++ b/README.md
@@ -1,19 +1,146 @@
-# CP-Template
-A repo to place github workflow templates.
+# cp-workflow-template
 
-## Folder structure
+Centralized GitHub Actions workflows for cp-\* repositories.
+
+All reusable workflows are called via `uses: CoolBitX-Technology/cp-workflow-template/.github/workflows/<file>@master`.
+
+---
+
+## Reusable Workflows
+
+### `assign_reviewers.yml`
+
+Assigns individual reviewers to PRs. Reviewer list is maintained here — other repos only need a caller workflow.
+
+```yaml
+jobs:
+  assign:
+    uses: CoolBitX-Technology/cp-workflow-template/.github/workflows/assign_reviewers.yml@master
 ```
-.
-└── workflows
-    ├── apply_terraform.yml
-    ├── assign_reviewers.yml
-    ├── build_and_test_image.yml
-    ├── notify_slack.yml
-    ├── plan_terraform.yml
-    ├── pr-action.yml
-    ├── push-action.yml
-    ├── push_and_rotate_image.yml
-    ├── run_integration_test.yml
-    ├── unit_test_than_build_image.yml
-    └── update_pr_description.yml
+
+---
+
+### `build_and_test_image.yml`
+
+Builds a Docker image and runs tests inside the container.
+
+```yaml
+jobs:
+  build:
+    uses: CoolBitX-Technology/cp-workflow-template/.github/workflows/build_and_test_image.yml@master
+    secrets:
+      PROD_CP_GCP_PROJECT_ID: ${{ secrets.PROD_CP_GCP_PROJECT_ID }}
+      DEV_CP_GCP_PROJECT_ID: ${{ secrets.DEV_CP_GCP_PROJECT_ID }}
+      DEVOPS_READ_PACKAGE_TOKEN: ${{ secrets.DEVOPS_READ_PACKAGE_TOKEN }}
 ```
+
+---
+
+### `unit_test_than_build_image.yml`
+
+Runs unit tests with Node.js, then builds a Docker image and uploads it as an artifact. Prefer this over `build_and_test_image.yml` for repos with a proper unit test setup.
+
+Inputs:
+- `node-version` (optional, default: `22.16.0`)
+
+```yaml
+jobs:
+  build:
+    uses: CoolBitX-Technology/cp-workflow-template/.github/workflows/unit_test_than_build_image.yml@master
+    with:
+      node-version: '22.16.0'
+    secrets:
+      PROD_CP_GCP_PROJECT_ID: ${{ secrets.PROD_CP_GCP_PROJECT_ID }}
+      DEV_CP_GCP_PROJECT_ID: ${{ secrets.DEV_CP_GCP_PROJECT_ID }}
+      DEVOPS_READ_PACKAGE_TOKEN: ${{ secrets.DEVOPS_READ_PACKAGE_TOKEN }}
+```
+
+---
+
+### `push_and_rotate_image.yml`
+
+Pushes the built image to GCR and rotates it in the cluster. Requires artifact from `build_and_test_image.yml` or `unit_test_than_build_image.yml`.
+
+```yaml
+jobs:
+  push:
+    needs: build
+    uses: CoolBitX-Technology/cp-workflow-template/.github/workflows/push_and_rotate_image.yml@master
+    secrets:
+      PROD_CP_GCP_PROJECT_ID: ${{ secrets.PROD_CP_GCP_PROJECT_ID }}
+      DEV_CP_GCP_PROJECT_ID: ${{ secrets.DEV_CP_GCP_PROJECT_ID }}
+      PROD_CP_GCP_SVC_TERRAFORM: ${{ secrets.PROD_CP_GCP_SVC_TERRAFORM }}
+      DEV_CP_GCP_SVC_TERRAFORM: ${{ secrets.DEV_CP_GCP_SVC_TERRAFORM }}
+      PROD_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE: ${{ secrets.PROD_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
+      DEV_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE: ${{ secrets.DEV_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
+```
+
+---
+
+### `plan_terraform.yml` / `apply_terraform.yml`
+
+Plan and apply Terraform changes. `apply_terraform.yml` typically runs after both `push_and_rotate_image` and `plan_terraform` succeed.
+
+```yaml
+jobs:
+  plan:
+    needs: build
+    uses: CoolBitX-Technology/cp-workflow-template/.github/workflows/plan_terraform.yml@master
+    secrets:
+      PROD_CP_GCP_PROJECT_ID: ${{ secrets.PROD_CP_GCP_PROJECT_ID }}
+      DEV_CP_GCP_PROJECT_ID: ${{ secrets.DEV_CP_GCP_PROJECT_ID }}
+      DEVOPS_ACCESS_REPO_TOKEN: ${{ secrets.DEVOPS_ACCESS_REPO_TOKEN }}
+      PROD_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE: ${{ secrets.PROD_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
+      DEV_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE: ${{ secrets.DEV_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
+
+  apply:
+    needs: [push, plan]
+    uses: CoolBitX-Technology/cp-workflow-template/.github/workflows/apply_terraform.yml@master
+    secrets: ...
+```
+
+---
+
+### `run_integration_test.yml`
+
+Runs integration tests and notifies a Slack user on completion.
+
+Required inputs: `OWNER_SLACK_ID`, `SERVICE`.
+
+---
+
+### `notify_slack.yml`
+
+Sends a Slack notification to the crypto platform channel.
+
+```yaml
+jobs:
+  notify:
+    needs: apply
+    uses: CoolBitX-Technology/cp-workflow-template/.github/workflows/notify_slack.yml@master
+    secrets:
+      CP_SLACK_CHANNEL_RG_CRYPTO: ${{ secrets.CP_SLACK_CHANNEL_RG_CRYPTO }}
+```
+
+---
+
+### `build_and_publish_npm_package.yml`
+
+Builds and publishes a package to the GitHub Packages (private `@coolbitx-technology` registry).
+
+---
+
+### `build_and_publish_official_public_npm_package.yml`
+
+Builds and publishes a package to the public npmjs.org registry under `@coolbitx` scope.
+
+---
+
+## Standalone Workflows
+
+| File | Trigger | Purpose |
+|---|---|---|
+| `push-action.yml` | `push` / `workflow_dispatch` | Example: composes build → push → terraform → notify |
+| `pr-action.yml` | `pull_request` | Example: Docker-based unit test + Slack notification |
+| `update_pr_description.yml` | `pull_request` → `master` | Auto-updates PR description |
+| `delete-failure-job.yml` | `workflow_dispatch` | Manually delete a failed k8s CronJob by namespace + name |


### PR DESCRIPTION
## Summary

- Rewrite `assign_reviewers.yml` as a reusable workflow (`workflow_call`), so all cp-* repos can call it instead of maintaining their own reviewer list
- Replace `kentaro-m/auto-assign-action` with `actions/github-script` — calls GitHub API directly, filters out PR author, no config file dependency
- Update README to reflect current workflow inventory with caller examples

## Motivation

Slack bots (GitHub App / typo) only notify on **individual** reviewer assignment, not team group assignment. We want individual assignment but without maintaining the list in every repo. Now the list lives in one place — update `assign_reviewers.yml` here and all repos pick it up automatically.

## How to migrate other repos

Replace the existing `assign_reviewers.yml` (and `auto_assign.yml` if present) with:

```yaml
name: Assign Reviewers

on:
  pull_request:
    types: [ready_for_review, opened]

jobs:
  assign:
    uses: CoolBitX-Technology/cp-workflow-template/.github/workflows/assign_reviewers.yml@master
```

## Test plan

- [ ] Open a PR in this repo and verify all 6 reviewers (minus the author) are assigned
- [ ] Verify Slack notification is received

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 **PR Summary by Typo**
------------

#### Overview
This PR centralizes the logic for assigning reviewers to pull requests within a reusable GitHub Actions workflow and significantly updates the project's `README.md` to document this and other reusable workflows.

#### Key Changes
- The `assign_reviewers.yml` workflow was converted into a reusable workflow (`workflow_call`).
- The reviewer assignment mechanism was switched from a third-party action to a custom `github-script` to allow for more flexible logic, including excluding the PR author from the assigned reviewers.
- A hardcoded list of reviewers is now maintained directly within the `assign_reviewers.yml` workflow.
- The `README.md` was extensively updated to provide comprehensive documentation and usage examples for all reusable workflows, including the new `assign_reviewers.yml`.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 151 (86.8%)   |
| Churn       | 1 (0.6%)      |
| Refactor    | 22 (12.6%)    |
| Total Changes | 174         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>