### PR TITLE
fix: use wildcard for allowed_bots in claude-code-action

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_AUTO_MERGE_TOKEN }}
-          allowed_bots: dependabot
+          allowed_bots: '*'
           prompt: |
             You are reviewing a Dependabot PR in repository ${{ github.repository }}.
 

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_AUTO_MERGE_TOKEN }}
-          allowed_bots: '*'
+          allowed_bots: 'dependabot[bot]'
           prompt: |
             You are reviewing a Dependabot PR in repository ${{ github.repository }}.
 


### PR DESCRIPTION
## Summary
- `dependabot`'s actual GitHub actor name is `dependabot[bot]` (with the `[bot]` suffix), so `allowed_bots: dependabot` didn't match
- Switch to `allowed_bots: '*'` — safe since this reusable workflow is only ever called by Dependabot auto-merge flows

## Test plan
- [ ] Trigger a Dependabot PR in cp-crypto-swap and verify the auto-merge Claude step runs without the "non-human actor" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)