### PR TITLE
fix: allow Bash tool in claude-code-action for dependabot workflow

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -133,6 +133,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_AUTO_MERGE_TOKEN }}
           allowed_bots: 'dependabot[bot]'
+          allowed_tools: 'Bash'
           prompt: |
             You are reviewing a Dependabot PR in repository ${{ github.repository }}.
 

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -133,7 +133,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_AUTO_MERGE_TOKEN }}
           allowed_bots: 'dependabot[bot]'
-          allowed_tools: 'Bash'
+          allowed_tools: 'Bash(gh:*),Bash(grep:*)'
           prompt: |
             You are reviewing a Dependabot PR in repository ${{ github.repository }}.
 


### PR DESCRIPTION
## Summary
- Root cause: in `agent` mode, `claude-code-action` defaults to `allowedTools: undefined` when no `allowed_tools` input is given. In non-interactive CI mode, Claude Code denies all tool calls without human approval → `permission_denials_count: 14`, nothing gets merged.
- Fix: add `allowed_tools: 'Bash'` so Claude can run the `gh` and `grep` commands specified in the prompt.

## Test plan
- [ ] Trigger a fresh Dependabot PR run (`@dependabot recreate`) and verify Claude runs to completion and labels/merges the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 **PR Summary by Typo**
------------

#### Overview
This PR fixes an issue by explicitly allowing the `Bash` tool within the `claude-code-action` for the Dependabot auto-merge workflow.

#### Key Changes
- Added `allowed_tools: 'Bash'` to the `claude-code-action` configuration in the `dependabot_auto_merge.yml` workflow.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| New Work | 1 (100.0%)    |
| Total Changes | 1         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>