### PR TITLE
fix: use claude_args --allowedTools instead of unsupported allowed_tools input

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -133,7 +133,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_AUTO_MERGE_TOKEN }}
           allowed_bots: 'dependabot[bot]'
-          allowed_tools: 'Bash(gh:*),Bash(grep:*)'
+          claude_args: '--allowedTools "Bash(gh:*)" "Bash(grep:*)"'
           prompt: |
             You are reviewing a Dependabot PR in repository ${{ github.repository }}.
 


### PR DESCRIPTION
## Summary
- `allowed_tools` is not a valid input for the pinned `claude-code-action@9dd8b95a` version (warning confirmed this)
- The correct approach is `claude_args: '--allowedTools "Bash(gh:*)" "Bash(grep:*)"'`
- Scope is still restricted to `gh` and `grep` only (no arbitrary shell access)

## Test plan
- [ ] Trigger a fresh Dependabot PR run and verify `permission_denials_count` drops to 0 and the PR gets labeled/merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)