### PR TITLE
feat: use claude-sonnet-4-6 for dependabot auto-merge analysis

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -230,6 +230,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_AUTO_MERGE_TOKEN }}
           allowed_bots: 'dependabot[bot]'
+          model: 'claude-sonnet-4-6'
           claude_args: '--allowedTools "Bash(gh:*)" "Bash(grep:*)" Read Write'
           prompt: |
             You are reviewing a Dependabot PR in repository ${{ github.repository }}.


### PR DESCRIPTION
## Summary
- Switch Claude model from default (Opus 4.8) to `claude-sonnet-4-6` for the Dependabot auto-merge analysis step
- Sonnet is sufficient for changelog analysis, bump type evaluation, and codebase usage grep — no need for Opus-level reasoning
- ~5x cost reduction per auto-merge run

## Test plan
- [ ] Trigger a Dependabot PR and verify the auto-merge workflow runs with Sonnet
- [ ] Confirm comment quality is not degraded
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the Dependabot auto-merge workflow to utilize the `claude-sonnet-4-6` model for analysis, aiming to improve the quality or efficiency of auto-merge decisions.

#### Key Changes
- The `dependabot_auto_merge.yml` workflow configuration was updated to specify `claude-sonnet-4-6` as the model for the auto-merge analysis step.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 1 (100.0%)    |
| Total Changes | 1             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>