### PR TITLE
fix: pass model via claude_args instead of invalid model input

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -230,8 +230,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_AUTO_MERGE_TOKEN }}
           allowed_bots: 'dependabot[bot]'
-          model: 'claude-sonnet-4-6'
-          claude_args: '--allowedTools "Bash(gh:*)" "Bash(grep:*)" Read Write'
+          claude_args: '--model claude-sonnet-4-6 --allowedTools "Bash(gh:*)" "Bash(grep:*)" Read Write'
           prompt: |
             You are reviewing a Dependabot PR in repository ${{ github.repository }}.
 


### PR DESCRIPTION
## Problem
PR #46 added `model: 'claude-sonnet-4-6'` as a direct input to `claude-code-action`, but the pinned version (`9dd8b95a`) does not support a `model` input — causing a warning and the setting being ignored.

## Fix
Move model spec into `claude_args` via `--model claude-sonnet-4-6`, which is the correct way to pass it in this version.
 
 **PR Summary by Typo**
------------

#### Overview
This PR fixes an issue where the Claude model was incorrectly specified as a direct input instead of being passed through `claude_args` in the Dependabot auto-merge workflow.

#### Key Changes
- The `model` input for the Claude action in `.github/workflows/dependabot_auto_merge.yml` has been removed.
- The Claude model (`claude-sonnet-4-6`) is now correctly passed as an argument within the `claude_args` input.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Churn    | 1 (50.0%)     |
| Rework   | 1 (50.0%)     |
| Total Changes | 2         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>